### PR TITLE
Fix pagination max

### DIFF
--- a/src/mixins/PaginableMixin.vue
+++ b/src/mixins/PaginableMixin.vue
@@ -27,7 +27,7 @@ export default {
 
       this.page = {
         current: Math.floor(data.offset / data.reqCount) + 1,
-        max: Math.ceil(data.total / data.reqCount),
+        max: Math.min(Math.ceil(data.total / data.reqCount), 50),
         list: [],
       };
 


### PR DESCRIPTION
Do not  render page buttons for pages not allowed to be loaded due to the limit of 1000 entries from sphinx.
Use the lowest page number possible based on `results / 20` or the max of 50 pages (50*20 = 1000)