### PR TITLE
Match dark style class name for prev button

### DIFF
--- a/src/assets/css/theme-dark.scss
+++ b/src/assets/css/theme-dark.scss
@@ -47,10 +47,10 @@
     background-color: #3e4b59;
   }
 
-  .pagination-link,.pagination-prev,.pagination-next {
+  .pagination-link,.pagination-previous,.pagination-next {
     color: #d6d4d0;
   }
-  .pagination-link:hover,.pagination-prev:hover,.pagination-next:hover {
+  .pagination-link:hover,.pagination-previous:hover,.pagination-next:hover {
     color: #dbdbdb;
   }
 }


### PR DESCRIPTION
https://github.com/predbdotovh/website-vuejs/blob/484b634753ba8923cc32125e5308efd647c08313/src/components/Pagination.vue#L5

Currently in dark mode the "Prev" button does not look as intended. Renaming to match dark mode style